### PR TITLE
status bar padding issue fix

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -1,20 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- * Copyright (c) 2006, The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/*
+** Copyright 2020, The LineageOS Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
 */
 -->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
 <resources>
-    <dimen name="rounded_corner_content_padding">52px</dimen>
+
+    <!-- the padding on the top of the statusbar (usually 0) -->
+    <dimen name="status_bar_padding_top">8dp</dimen>
+
+    <!-- the padding on the rouded corner content -->
+    <dimen name="rounded_corner_content_padding">6dp</dimen>
+
+    <!-- the padding on the start of the statusbar -->
+    <dimen name="status_bar_padding_start">15dp</dimen>
+
+    <!-- the padding on the end of the statusbar -->
+    <dimen name="status_bar_padding_end">18dp</dimen>
+
+    <!-- the padding on the end of the keyguard statusbar -->
+    <dimen name="system_icons_keyguard_padding_end">15dp</dimen>
+    
+<!--     <dimen name="qqs_padding_top">20dp</dimen> -->
+
+    <!--  Allow CornerHandleView and PathSpecCornerPathRenderer to decouple from corner-radius -->
+    <dimen name="config_rounded_mask_size">113px</dimen>
+
 </resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -1,44 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-/*
-** Copyright 2020, The LineageOS Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
+ * Copyright (c) 2006, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
 */
 -->
-
-<!-- These resources are around just to allow their values to be customized
-     for different hardware and product builds. -->
 <resources>
-
-    <!-- the padding on the top of the statusbar (usually 0) -->
     <dimen name="status_bar_padding_top">8dp</dimen>
-
-    <!-- the padding on the rouded corner content -->
-    <dimen name="rounded_corner_content_padding">6dp</dimen>
-
-    <!-- the padding on the start of the statusbar -->
-    <dimen name="status_bar_padding_start">15dp</dimen>
-
-    <!-- the padding on the end of the statusbar -->
-    <dimen name="status_bar_padding_end">18dp</dimen>
-
-    <!-- the padding on the end of the keyguard statusbar -->
-    <dimen name="system_icons_keyguard_padding_end">15dp</dimen>
-    
-<!--     <dimen name="qqs_padding_top">20dp</dimen> -->
-
-    <!--  Allow CornerHandleView and PathSpecCornerPathRenderer to decouple from corner-radius -->
-    <dimen name="config_rounded_mask_size">113px</dimen>
-
+    <dimen name="rounded_corner_content_padding">52px</dimen>
 </resources>


### PR DESCRIPTION
values from havoc for alioth (ref: https://github.com/Havoc-Devices/android_device_xiaomi_alioth/blob/eleven/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml#L25 )